### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ embedded-hal = "1.0.0"
 nb = "1.0"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.7"
+embedded-hal-bus = "0.2.0"
+embedded-hal-mock = { version = "0.11.*", features = ["eh1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "max31856"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["dheepan <idheepan@gmail.com>"]
 repository = "https://github.com/idheepan/max31856-rs"
 edition = "2018"
@@ -23,7 +23,7 @@ include = [
 coveralls = { repository = "idheepan/max31856-rs", branch = "master", service = "github" }
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = "1.0.0"
 nb = "1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Rust driver for MAX31856
 
-Uses [`embedded-hal`](https://github.com/rust-embedded/embedded-hal) traits and patterns from Eldruin's [`driver-examples`](https://github.com/eldruin/driver-examples)
+Uses [`embedded-hal`](https://github.com/rust-embedded/embedded-hal) 1.0.0 traits (SpiDevice) and patterns from Eldruin's [`driver-examples`](https://github.com/eldruin/driver-examples)
+
+Communication with MAX31856 only works with Spi Mode 1 or 3.
 
 Features:
-- Modify default configuration. see `config()`
+- Modify default configuration. See: `config()`
 - Read/write configuration. See: `send_config()`
 - Read Linearized thermocouple temperature in Celcius. See: `temperature()`
+- Read Fault status. See: `fault_status()`
 
 Features in the next few versions:
 - Interrupts with FAULT pin
@@ -15,24 +18,28 @@ Features in the next few versions:
 - Read/write Linearized temperature fault registers.
 - Read/write cold junction temperature offset registers. 
 - Read cold junction temperature. 
-- Read Fault status. 
 
 ## Usage example
-```
-extern crate max31856
-extern crate linux_embedded_hal
+```rust
+use max31856;
 
-let spi = Spidev::open("/dev/spidev0.0").unwrap();
-let cs = Pin::new(25);
-let fault = Pin::new(23); //Fault pin is unused
-let mut sensor = Max31856::new(spi, cs, fault);
-// A default configuration is set on creation. It can be edited as follows
-sensor.config().average_samples(max31856::AveragingMode::FourSamples);
-sensor.send_config();
-println!(sensor.temperature().unwrap());
-sensor.config().conversion_mode(max31856::CMode::AutomaticConversion);
-sensor.send_config();
-println!(sensor.temperature().unwrap());
+fn example<S, FP>(spi_dev: S, fault_pin: FP) -> Result<(), max31856::Error>
+where
+    S: embedded_hal::spi::SpiDevice,
+    FP: embedded_hal::digital::InputPin,
+{
+    let mut sensor = max31856::Max31856::new(spi_dev, fault_pin);
+    // A default configuration is set on creation. It can be edited as follows
+    sensor.config().average_samples(max31856::AveragingMode::FourSamples);
+    let _ = sensor.send_config();
+    println!("Temperature: {}", sensor.temperature().unwrap());
+    sensor.config().conversion_mode(max31856::CMode::AutomaticConversion);
+    let _ = sensor.send_config();
+    println!("Temperature: {}", sensor.temperature().unwrap());
+    // Faults can be assessed via 
+    println!("Status: {:?}", sensor.fault_status()); 
+    Ok(())
+}
 ```
 ## Support
 

--- a/examples/readme_test.rs
+++ b/examples/readme_test.rs
@@ -1,0 +1,94 @@
+use max31856;
+
+use embedded_hal;
+use embedded_hal_bus::spi::ExclusiveDevice;
+
+// fake stuff for example
+struct FakeSpiBus();
+
+impl embedded_hal::spi::ErrorType for FakeSpiBus {
+    type Error = core::convert::Infallible;
+}
+
+impl embedded_hal::spi::SpiBus<u8> for FakeSpiBus {
+    fn read(&mut self, _: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn write(&mut self, _: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn transfer(&mut self, _: &mut [u8], _: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn transfer_in_place(&mut self, _: &mut [u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+struct FakeCs();
+
+impl embedded_hal::digital::ErrorType for FakeCs {
+    type Error = core::convert::Infallible;
+}
+
+impl embedded_hal::digital::OutputPin for FakeCs {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+struct FakeFault();
+
+impl embedded_hal::digital::ErrorType for FakeFault {
+    type Error = core::convert::Infallible;
+}
+
+impl embedded_hal::digital::InputPin for FakeFault {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FakeDelayer();
+
+impl embedded_hal::delay::DelayNs for FakeDelayer {
+    fn delay_ns(&mut self, ns: u32) {
+        std::thread::sleep(std::time::Duration::from_nanos(u64::from(ns)));
+    }
+}
+
+fn main () {
+    // BEGIN fake stuff that has to be replaced with real peripherals
+    let spi_bus = FakeSpiBus();
+    let delay = FakeDelayer();
+    let fault_pin = FakeFault();
+    let spi_dev = ExclusiveDevice::new(spi_bus, FakeCs(), delay).unwrap();
+    // END fake stuff that has to be replaced with real peripherals
+
+    let mut sensor = max31856::Max31856::new(spi_dev, fault_pin);
+    // A default configuration is set on creation. It can be edited as follows
+    sensor.config().average_samples(max31856::AveragingMode::FourSamples);
+    let _ = sensor.send_config();
+    println!("Temperature: {}", sensor.temperature().unwrap());
+    sensor.config().conversion_mode(max31856::CMode::AutomaticConversion);
+    let _ = sensor.send_config();
+    println!("Temperature: {}", sensor.temperature().unwrap());
+    // Faults can be assessed via 
+    println!("Status: {:?}", sensor.fault_status()); 
+}

--- a/examples/rpi_linux.rs
+++ b/examples/rpi_linux.rs
@@ -1,6 +1,0 @@
-use linux_embedded_hal::{Spidev, Pin};
-
-fn main() {
-    let _spi = Spidev::open("/dev/spidev0.0").unwrap();
-    let _chip_select = Pin::new(25);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,22 @@
 //! Rust driver for MAX31856
 //!
-//! Uses [`embedded-hal`] traits and patterns from Eldruin's [`driver-examples`]
+//! Uses [`embedded-hal`] 1.0.0 traits (SpiDevice) and patterns from Eldruin's [`driver-examples`]
 //!
 //! [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 //! [`driver-examples`]: https://github.com/eldruin/driver-examples
+//! 
+//! Communication with MAX31856 only works with Spi Mode 1 or 3.
 //!
 //! Features:
-//! - Modify default configuration. see [`config()`]
+//! - Modify default configuration. See: [`config()`]
 //! - Read/write configuration. See: [`send_config()`]
 //! - Read Linearized thermocouple temperature in Celcius. See: [`temperature()`]
+//! - Read Fault status. See: [`fault_status()`]
 //!
 //! [`config()`]: struct.Max31856.html#method.config
 //! [`send_config()`]: struct.Max31856.html#method.send_config
 //! [`temperature()`]: struct.Max31856.html#method.temperature
+//! [`fault_status()`]: struct.Max31856.html#method.fault_status
 //!
 //! Features in the next few versions:
 //! - Interrupts with FAULT pin
@@ -22,24 +26,28 @@
 //! - Read/write Linearized temperature fault registers.
 //! - Read/write cold junction temperature offset registers. 
 //! - Read cold junction temperature. 
-//! - Read Fault status. 
 //! 
 //! ## Usage example
 //! ```
-//! extern crate max31856
-//! extern crate linux_embedded_hal
+//! use max31856;
 //! 
-//! let spi = Spidev::open("/dev/spidev0.0").unwrap();
-//! let cs = Pin::new(25);
-//! let fault = Pin::new(23); //Fault pin is unused
-//! let mut sensor = Max31856::new(spi, cs, fault);
-//! // A default configuration is set on creation. It can be edited as follows
-//! sensor.config().average_samples(max31856::AveragingMode::FourSamples);
-//! sensor.send_config();
-//! println!(sensor.temperature().unwrap());
-//! sensor.config().conversion_mode(max31856::CMode::AutomaticConversion);
-//! sensor.send_config();
-//! println!(sensor.temperature().unwrap());
+//! fn example<S, FP>(spi_dev: S, fault_pin: FP) -> Result<(), max31856::Error>
+//! where
+//!     S: embedded_hal::spi::SpiDevice,
+//!     FP: embedded_hal::digital::InputPin,
+//! {
+//!     let mut sensor = max31856::Max31856::new(spi_dev, fault_pin);
+//!     // A default configuration is set on creation. It can be edited as follows
+//!     sensor.config().average_samples(max31856::AveragingMode::FourSamples);
+//!     let _ = sensor.send_config();
+//!     println!("Temperature: {}", sensor.temperature().unwrap());
+//!     sensor.config().conversion_mode(max31856::CMode::AutomaticConversion);
+//!     let _ = sensor.send_config();
+//!     println!("Temperature: {}", sensor.temperature().unwrap());
+//!     // Faults can be assessed via 
+//!     println!("Status: {:?}", sensor.fault_status()); 
+//!     Ok(())
+//! }
 //! ```
 //! 
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,10 +1,8 @@
-extern crate max31856;
-extern crate embedded_hal_mock as hal;
-use self::hal::spi::{Mock as SpiMock, 
+use max31856;
+use embedded_hal_mock as hal;
+use self::hal::eh1::spi::{Mock as SpiMock, 
     Transaction as SpiTransaction};
-use self::hal::pin::{Transaction as PinTransaction, 
-    Mock as PinMock, 
-    State as PinState};
+use self::hal::eh1::digital::Mock as PinMock;
 use self::max31856::{Max31856, Error};
 
 #[test]
@@ -18,93 +16,78 @@ fn can_create_max31856_options() {
 fn can_send_configuration(){
     // SPI transactions
     let spi_expectations = [
-        SpiTransaction::write(vec![0x80, 0]), //Write C0
-        SpiTransaction::write(vec![0x81, 0x23]), //Write C1
-    ];
-    // Pin transactions
-    let pin_expectations = [
-        PinTransaction::set(PinState::Low),
-        PinTransaction::set(PinState::High),
-        PinTransaction::set(PinState::Low),
-        PinTransaction::set(PinState::High),
+        SpiTransaction::transaction_start(),
+        SpiTransaction::write_vec(vec![0x80, 0]), //Write C0
+        SpiTransaction::transaction_end(),
+        SpiTransaction::transaction_start(),
+        SpiTransaction::write_vec(vec![0x81, 0x23]), //Write C1
+        SpiTransaction::transaction_end(),
     ];
 
-    let spi = SpiMock::new(&spi_expectations);
-    let cs = PinMock::new(&pin_expectations);
-    let fault = PinMock::new(&pin_expectations);
+    let mut spi = SpiMock::new(&spi_expectations);
+    let mut fault = PinMock::new(&[]);
 
-    let mut sensor = Max31856::new(spi, cs, fault);
+    let mut sensor = Max31856::new(&mut spi, &mut fault);
     sensor.config().average_samples(max31856::AveragingMode::FourSamples);
     sensor.send_config().unwrap();
+    spi.done();
+    fault.done();
 }
 
 #[test]
 fn can_read_temperature_normally_off() {
-        // SPI transactions
-        let spi_expectations = [
-            SpiTransaction::write(vec![0x80, 0x40]), //Write oneshot c0
-            SpiTransaction::transfer(vec![0x0C, 0,0,0], vec![0x0C, 0x05, 0x72, 0xC0]), //Write C1
-        ];
-        // Pin transactions
-        let pin_expectations = [
-            //Setting C0 for one shot
-            PinTransaction::set(PinState::Low),
-            PinTransaction::set(PinState::High),
-            //Transfering data
-            PinTransaction::set(PinState::Low),
-            PinTransaction::set(PinState::High),
-        ];
-    
-        let spi = SpiMock::new(&spi_expectations);
-        let cs = PinMock::new(&pin_expectations);
-        let fault = PinMock::new(&pin_expectations);
-        let mut sensor = Max31856::new(spi, cs, fault);
-        assert_eq!(sensor.temperature().unwrap(), 87.171875);
+    // SPI transactions
+    let spi_expectations = [
+        SpiTransaction::transaction_start(),
+        SpiTransaction::write_vec(vec![0x80, 0x40]), //Write oneshot c0
+        SpiTransaction::transaction_end(),
+        SpiTransaction::transaction_start(),
+        SpiTransaction::transfer_in_place(vec![0x0C, 0,0,0], vec![0x0C, 0x05, 0x72, 0xC0]), //Read temperature registers
+        SpiTransaction::transaction_end(),
+    ];
+
+    let mut spi = SpiMock::new(&spi_expectations);
+    let mut fault = PinMock::new(&[]);
+    let mut sensor = Max31856::new(&mut spi, &mut fault);
+    assert_eq!(sensor.temperature().unwrap(), 87.171875);
+    spi.done();
+    fault.done();
 }
 
 #[test]
 fn can_read_negative_temperature_normally_off() {
     // SPI transactions
     let spi_expectations = [
-        SpiTransaction::write(vec![0x80, 0x40]), //Write oneshot c0
-        SpiTransaction::transfer(vec![0x0C, 0,0,0], vec![0x0C, 0x85, 0x72, 0xC0]), //Write C1
-    ];
-    // Pin transactions
-    let pin_expectations = [
-        //Setting C0 for one shot
-        PinTransaction::set(PinState::Low),
-        PinTransaction::set(PinState::High),
-        //Transfering data
-        PinTransaction::set(PinState::Low),
-        PinTransaction::set(PinState::High),
+        SpiTransaction::transaction_start(),
+        SpiTransaction::write_vec(vec![0x80, 0x40]), //Write oneshot c0
+        SpiTransaction::transaction_end(),
+        SpiTransaction::transaction_start(),
+        SpiTransaction::transfer_in_place(vec![0x0C, 0,0,0], vec![0x0C, 0x85, 0x72, 0xC0]), //Read temperature registers
+        SpiTransaction::transaction_end(),
     ];
 
-    let spi = SpiMock::new(&spi_expectations);
-    let cs = PinMock::new(&pin_expectations);
-    let fault = PinMock::new(&pin_expectations);
-    let mut sensor = Max31856::new(spi, cs, fault);
+    let mut spi = SpiMock::new(&spi_expectations);
+    let mut fault = PinMock::new(&[]);
+    let mut sensor = Max31856::new(&mut spi, &mut fault);
     assert_eq!(sensor.temperature().unwrap(), -87.171875);
+    spi.done();
+    fault.done();
 }
 
 #[test]
 fn can_get_fault_status(){
-        // SPI transactions
-        let spi_expectations = [
-            SpiTransaction::transfer(vec![0x0F, 0], vec![0x0F, 0x15]), //Write C1
-        ];
-        // Pin transactions
-        let pin_expectations = [
-            //Transfering data
-            PinTransaction::set(PinState::Low),
-            PinTransaction::set(PinState::High),
-        ];
+    // SPI transactions
+    let spi_expectations = [
+        SpiTransaction::transaction_start(),
+        SpiTransaction::transfer_in_place(vec![0x0F, 0], vec![0x0F, 0x15]), //Read fault status register
+        SpiTransaction::transaction_end(),
+    ];
 
-        let spi = SpiMock::new(&spi_expectations);
-        let cs = PinMock::new(&pin_expectations);
-        let fault = PinMock::new(&pin_expectations);
-        let mut sensor = Max31856::new(spi, cs, fault);
-        let result = sensor.fault_status();
-        match result {
+    let mut spi = SpiMock::new(&spi_expectations);
+    let mut fault = PinMock::new(&[]);
+    let mut sensor = Max31856::new(&mut spi, &mut fault);
+    let result = sensor.fault_status();
+    match result {
         Err(Error::Device(errors)) => {
             assert_eq!(false, errors.cold_junction_out_of_range);
             assert_eq!(false, errors.thermocouple_out_of_range);
@@ -117,4 +100,6 @@ fn can_get_fault_status(){
         }
         _ => panic!("Wrong result"),
     }
+    spi.done();
+    fault.done();
 }


### PR DESCRIPTION
Update of the driver to support embedded-hal 1.0.0 with the SpiDevice trait.
Tests, example and doc all updated accordingly, and the driver was tested with an esp32s3.